### PR TITLE
Add support for Python's virtualenvs

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -2,6 +2,7 @@
 # set theme_display_rbenv 'yes' (config.fish)
 # set theme_display_rbenv_gemset 'yes' (config.fish)
 # set theme_display_rbenv_with_gemfile_only 'yes' (config.fish)
+# set theme_display_venv 'yes' (config.fish)
 
 function _ruby_version
   echo (command rbenv version-name | sed 's/\n//')
@@ -9,6 +10,15 @@ end
 
 function _ruby_gemset
   echo (command rbenv gemset active ^/dev/null | sed -e 's| global||')
+end
+
+function _show_venv
+  if [ "$VIRTUAL_ENV" ]
+    if [ "$theme_display_rbenv" = 'yes' ]
+       echo -n " "
+    end
+    echo -n -s (set_color green) (basename $VIRTUAL_ENV) (set_color normal)()
+  end
 end
 
 function fish_right_prompt
@@ -33,5 +43,9 @@ function fish_right_prompt
     else
       echo -n -s $ruby_info $normal
     end
+  end
+
+  if [ "$theme_display_venv" = 'yes' ]
+    _show_venv
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ $ omf theme l
 ## Configuration
 
 Only if fish_theme_l_right_prompt variable is set true within config.fish:
+
+### rbenv support
+
 ```fish
 set theme_display_rbenv 'yes'
 set theme_display_rbenv_gemset 'yes'
@@ -44,6 +47,17 @@ set theme_display_rbenv_with_gemfile_only 'yes'
 <img src="http://f.cl.ly/items/0f0k3o2L3y2q1L3g1R1X/5.png">
 </p>
 
+
+### Python venv support
+
+If you're using [virtualfish][] and enable the `theme_display_venv` setting with
+the following line in your `config.fish`, the currently active virtualenv is
+part of the right-side-prompt, highlighted in green:
+
+```fish
+set theme_dispay_venv 'yes'
+```
+
 # License
 
 [MIT][mit] © [bpinto][author] et [al][contributors]
@@ -57,4 +71,4 @@ set theme_display_rbenv_with_gemfile_only 'yes'
 [license-badge]:  https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square
 [travis-badge]:   http://img.shields.io/travis/oh-my-fish/theme-default.svg?style=flat-square
 [travis-link]:    https://travis-ci.org/oh-my-fish/theme-default
-
+[virtualfish]:    https://github.com/adambrenecki/virtualfish


### PR DESCRIPTION
Currently the theme supports only rbenv. I thought it might be useful to also integrate Python's virtualenv support as exposed with virtualfish to the right side prompt 🙂
